### PR TITLE
OtherApiClient Patch

### DIFF
--- a/bridge_adaptivity/api/backends/api_client.py
+++ b/bridge_adaptivity/api/backends/api_client.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 import logging
 
 from django.utils.translation import ugettext as _
-from slumber.exceptions import HttpClientError, HttpNotFoundError
+from slumber.exceptions import HttpClientError, HttpNotFoundError, ImproperlyConfigured
 
 from api.backends.base_api_client import BaseApiClient
 from api.backends.dart_api_client import DartApiClient
@@ -108,15 +108,14 @@ def get_available_courses(request, source_ids=None):
         # Get API client instance:
         try:
             api = api_client_factory(content_source=content_source)
-            if api != "Other":
-                all_courses.extend(
-                    apply_data_filter(
-                        api.get_provider_courses(),
-                        filters=['id', 'course_id', 'name', 'org', 'content_source_id'],
-                        content_source_id=content_source.id
-                    )
+            all_courses.extend(
+                apply_data_filter(
+                    api.get_provider_courses(),
+                    filters=['id', 'course_id', 'name', 'org', 'content_source_id'],
+                    content_source_id=content_source.id
                 )
-        except HttpClientError as exc:
+            )
+        except (HttpClientError, ImproperlyConfigured) as exc:
             errors[str(exc)].append(content_source.name)
 
     # Convert defaultdict to dict, because django template doesn't work with defaultdict

--- a/bridge_adaptivity/api/backends/api_client.py
+++ b/bridge_adaptivity/api/backends/api_client.py
@@ -65,7 +65,7 @@ def get_available_blocks(request, source_id, course_id=''):
 
     # Get API client instance:
     api = api_client_factory(content_source=content_source)
-    if api != "Other":
+    if not isinstance(api, OtherApiClient):
         try:
         # filter function will be applied to api response
             all_blocks.extend(

--- a/bridge_adaptivity/api/backends/base_api_client.py
+++ b/bridge_adaptivity/api/backends/base_api_client.py
@@ -47,3 +47,8 @@ class BaseApiClient(slumber.API):
             return resource.get('results')
         except ConnectionError:
             raise slumber.exceptions.HttpClientError(_("Incorrect URL."))
+        except AttributeError:
+            # This can occur when the list of courses is fetched. If the response
+            # from the page is successful, but contains data in an unexpected format,
+            # the call to resource.get() will fail.
+            raise slumber.exceptions.ImproperlyConfigured(_("Unexpected response from API."))

--- a/bridge_adaptivity/api/backends/other_api_client.py
+++ b/bridge_adaptivity/api/backends/other_api_client.py
@@ -21,8 +21,7 @@ class OtherApiClient(BaseApiClient, EdxRestApiClient):
     def __init__(self, content_source):
         #  Removed this because of the BaseAPIClient get the content blocks from source to view the in bridge
         #TODO: Modify this according the other platform requirments
-        # BaseApiClient.__init__(self, content_source=content_source)
-        self.content_source = content_source
+        BaseApiClient.__init__(self, content_source=content_source)
         log.debug("Creating new OpenEdx API client...")
         log.debug(self.content_source.host_url)
         # Currently we are removing Authentication for OtherAPIClient Prototype 

--- a/bridge_adaptivity/bridge_lti/consumer.py
+++ b/bridge_adaptivity/bridge_lti/consumer.py
@@ -136,6 +136,8 @@ def source_preview(request):
 
         consumer_prams['consumer_key'] = content_provider.provider_key
         consumer_prams['consumer_secret'] = content_provider.provider_secret
+    else:
+        return render(request, 'bridge_lti/stub.html')
 
     source_name, source_lti_url, consumer_prams = create_lti_launch_params(request, sequence_item_id, consumer_prams)
     

--- a/bridge_adaptivity/bridge_lti/consumer.py
+++ b/bridge_adaptivity/bridge_lti/consumer.py
@@ -100,7 +100,7 @@ def source_preview(request):
             # Required parameters
             'lti_message_type': 'basic-lti-launch-request',
             'lti_version': 'LTI-1p0',
-            'resource_link_id': 'reaource_link_id',
+            'resource_link_id': 'resource_link_id',
             # Recommended parameters
             'user_id': 'bridge_user',
             'roles': 'Learner',


### PR DESCRIPTION
The AttributeError exception that we were seeing before was due to the Slumber API constructor not being called. There was a variable within the class that was referenced elsewhere in code, `_store`, that was unavailable without this.

I uncommented the constructor for BaseApiClient, and removed the check to see if the API is specifically the "Other" API client. Instead, the exception is caught and displayed in the adaptive bridge.

I'm not sure if this is was the direction the existing changes were going in, so I'm completely open to suggestions. Thanks!